### PR TITLE
Fix patchVersion checkbox config issue

### DIFF
--- a/Divination.FaloopIntegration/Config/PluginConfigWindow.cs
+++ b/Divination.FaloopIntegration/Config/PluginConfigWindow.cs
@@ -63,7 +63,7 @@ public class PluginConfigWindow : ConfigWindow<PluginConfig>
             foreach (var patchVersion in Enum.GetValues<MajorPatch>())
             {
                 ref var value = ref CollectionsMarshal.GetValueRefOrAddDefault(config.MajorPatches, patchVersion, out _);
-                ImGui.Checkbox(Enum.GetName(patchVersion), ref value);
+                ImGui.Checkbox($"{Enum.GetName(patchVersion)}##{label}", ref value);
                 ImGui.SameLine();
             }
             ImGui.Unindent();


### PR DESCRIPTION
Fixes and issue in the configuration windows where only S Ranks checkboxes for expansions were working.